### PR TITLE
Fix: Change nav link color and update citation status

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     }
 
     .nav-links a {
-      color: #fff;
+      color: #000;
       text-decoration: none;
       font-weight: 500;
       transition: all 0.3s ease;
@@ -912,7 +912,7 @@ cv2.waitKey(0)</code></pre>
       <div class="glass-card">
         <h2 class="section-title">Citation</h2>
         <p class="section-subtitle">
-          If you use PEOD in your research, please cite our paper (currently under review)
+          If you use PEOD in your research, please cite our paper (forthcoming)
         </p>
 
         <div class="highlight-box">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches nav link color to black and updates the citation subtitle wording in index.html.
> 
> - **UI/Styles**:
>   - Update `index.html` ` .nav-links a` color from `#fff` to `#000`.
> - **Content**:
>   - Change citation subtitle text to “forthcoming” in `#citation` section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c18cad30f8c818cbf3f5a5bf1e6fe797670e97d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->